### PR TITLE
Fix: Remove deprecated affectsInputRegion option for GNOME 50 compatibility

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -25,9 +25,7 @@ export default class WindowDimensionsExtension extends Extension {
         });
 
         // Add label to the UI
-        Main.layoutManager.addChrome(this._label, {
-            affectsInputRegion: false
-        });
+        Main.layoutManager.addChrome(this._label);
 
         // Connect to window grab events
         let display = global.display;


### PR DESCRIPTION
## Summary
Fixes a crash on GNOME 50 caused by an unrecognized parameter passed to `addChrome()`.

## Problem
The `affectsInputRegion` option was removed from `Main.layoutManager.addChrome()` in GNOME 50. Passing it causes the following error, which prevents the extension from loading:

```
Error: Unrecognized parameter "affectsInputRegion"
```

## Fix
Remove the options object from the `addChrome()` call. Since the label is a passive display element that is hidden by default and only shown briefly during resize operations, this option was precautionary and its removal has no impact on behavior.

## Testing
Tested on GNOME 50 (Wayland). Extension loads without errors and displays window dimensions correctly during resize.